### PR TITLE
Set the URL of the listening server

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -45,6 +45,12 @@ local function normalize(img, opts)
   return img
 end
 
+-- Set the URL of the listening server
+function M.server(config)
+  local port = config.port or 8000
+  local hostname = config.hostname or '127.0.0.1'
+  M.url = 'http://' .. hostname .. ':' .. port ..'/events'
+end
 
 function M.image(img, opts)
   -- options:

--- a/init.lua
+++ b/init.lua
@@ -46,7 +46,7 @@ local function normalize(img, opts)
 end
 
 -- Set the URL of the listening server
-function M.server(config)
+function M.configure(config)
   local port = config.port or 8000
   local hostname = config.hostname or '127.0.0.1'
   M.url = 'http://' .. hostname .. ':' .. port ..'/events'


### PR DESCRIPTION
If you start the server on a non-default hostname or port, before plotting you need to change the URL of the server manually with:

```
display = require('display')
display.url = .. -- the non-default URL
```

Otherwise the messages would be forwarded to the default hostname and port. 

I have added a convenience function that takes the hostname and port as a table and sets the URL from it, so you can do:

```
display = require('display')
display.configure({port=8001, hostname='example.com'}) 
```
