### PR TITLE
Default Tensor type fix

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -60,6 +60,12 @@ function M.configure(config)
 end
 
 function M.image(img, opts)
+
+  local defaultType = torch.getdefaulttensortype()
+  -- the image package expects this to be DoubleTensor 
+  -- if CudaTensor then clampImage from package image will attempt to index field 'image' (a nil value) of the CudaTensor
+  torch.setdefaulttensortype('torch.DoubleTensor') 
+
   -- options:
   opts = opts or {}
 
@@ -82,6 +88,7 @@ function M.image(img, opts)
   local inmem_img = image.compressJPG(img)
   local imgdata = 'data:image/jpg;base64,' .. mime.b64(ffi.string(inmem_img:data(), inmem_img:nElement()))
 
+  torch.setdefaulttensortype(defaultType)
 
   return pane('image', opts.win, opts.title, { src=imgdata, labels=opts._labels, width=opts.width })
 end

--- a/static/panes.js
+++ b/static/panes.js
@@ -117,12 +117,6 @@ function Pane(id) {
   cloneButton.innerHTML = 'o';
   cloneButton.title = 'disconnect';
 
-  var saveButton = document.createElement('a');
-  saveButton.innerHTML = '&#10515;';
-  saveButton.title = 'save';
-  saveButton.download = 'untitled_image.jpg';
-  saveButton.href = '';
-
   var title = document.createElement('div');
   title.className = 'title';
 
@@ -135,14 +129,12 @@ function Pane(id) {
   this.grip = grip;
   this.title = title;
   this.content = content;
-  this.saveButton = saveButton;
 
   el.appendChild(grip);
   el.appendChild(bar);
   el.appendChild(content);
   bar.appendChild(closeButton);
   bar.appendChild(cloneButton);
-  bar.appendChild(saveButton);
   bar.appendChild(title);
   body.appendChild(el);
 
@@ -196,7 +188,6 @@ function Pane(id) {
 Pane.prototype = {
   setTitle: function(title) {
     this.title.innerHTML = title;
-    this.saveButton.download = title.replace(/\s+/g, '_') + '.jpg';
   },
 
   focus: function() {
@@ -343,6 +334,12 @@ function ImagePane(id) {
   var self = this
     , content = this.content;
 
+  var saveButton = document.createElement('a');
+  saveButton.innerHTML = '&#11015;';
+  saveButton.title = 'save';
+  saveButton.download = 'untitled_image.jpg';
+  saveButton.href = '';
+
   var image = document.createElement('img');
   image.className = 'content-image';
   content.appendChild(image);
@@ -351,6 +348,10 @@ function ImagePane(id) {
   labels.className = 'labels';
   content.appendChild(labels);
 
+
+  this.bar.appendChild(saveButton);
+
+  this.saveButton = saveButton;
   this.content = image;
   this.labels = labels;
   this.width = 0;
@@ -379,8 +380,6 @@ function ImagePane(id) {
 
   on(image, 'load', function(ev) {
     if ((image.naturalWidth != self.width) || (image.naturalHeight != self.height)) {
-      self.width = image.naturalWidth;
-      self.height = image.naturalHeight;
       self.reset();
     }
   });
@@ -487,10 +486,13 @@ ImagePane.prototype = extend(Object.create(Pane.prototype), {
   },
 
   setContent: function(content) {
+
+    this.saveButton.href = content.src;
+    this.saveButton.download = this.title.innerHTML.replace(/\s+/g, '_') + '.jpg';
+
     // Hack around unexpected behavior. Setting .src resets .style (except 'position: absolute').
     var oldCss = this.content.style.cssText;
     this.content.src = content.src;
-    this.saveButton.href = content.src;
     this.content.style.cssText = oldCss;
     if (this.content.style.cssText != oldCss) {
       this.content.style.cssText = oldCss;


### PR DESCRIPTION
There is a bug if you set the default tensor type to `CudaTensor`. For example:

```
 local display   = require 'display'
torch.setdefaulttensortype('torch.CudaTensor')

-- then call
display.image(torch.randn(16, 3, 32, 32)
```

The `display.image` would call `image.compressJPG(img)` which in turns calls `image.clampImage(..)`. There, these two lines cause problem:
`init.lua165:` from `image` package 

```
local a = torch.Tensor():resize(tensor:size()):copy(tensor)
a.image.saturate(a) -- bound btwn 0 and 1
```

Here `a` is a default type tensor and if that is set to `CudaTensor` it won't have the field `image`. 

This PR is fixing the bug by setting the default tensor type to `DoubleTensor` and then restoring to the original state. 
