### PR TITLE
set this.(width|height)

### DIFF
--- a/static/panes.js
+++ b/static/panes.js
@@ -402,6 +402,8 @@ ImagePane.prototype = extend(Object.create(Pane.prototype), {
     c.style.top = '';
     c.style.width ='';
     c.style.height = '';
+    this.width = c.naturalWidth;
+    this.height = c.naturalHeight;
     this.resizeLabels();
     this.scale = Math.min(el.offsetWidth / c.naturalWidth, el.offsetHeight / c.naturalHeight);
   },


### PR DESCRIPTION
This fixes a bug introduced in [f918e](https://github.com/szym/display/commit/f918e52c07b6cd46b509499283ebd03bd5b45504#diff-94efb2e07cfa87c83408f046fdcf5d5fL382) in which `this.width` and `this.height` are never initialized. This prevents [zooming](https://github.com/szym/display/blob/master/static/panes.js#L451) from working correctly.

The fix is to simply initialize the pane's content width and height.